### PR TITLE
Fixed Geocoding Test

### DIFF
--- a/geocoding/src/test/java/io/swagger/client/api/GeocodingApiTest.java
+++ b/geocoding/src/test/java/io/swagger/client/api/GeocodingApiTest.java
@@ -119,8 +119,7 @@ public class GeocodingApiTest {
 
         // Default Limit and Locale
         assertEquals(1,response.getHits().size());
-        // TODO Why is locale null here? Maybe we should add it to the geocoding-converter?
-        assertEquals(null,response.getLocale());
+        assertEquals("de",response.getLocale());
 
         assertEquals("Wernau (Neckar), Baden-Württemberg, Deutschland",response.getHits().get(0).getName());
         assertEquals(48.68825915,response.getHits().get(0).getPoint().getLat(), .001);


### PR DESCRIPTION
I think the failing test, shown in #38 was due to the addition of the locale to the geocoding-converter. Therefore I changed the assert. As you can see there was also a TODO :).