### PR TITLE
Added exited parsing to the client

### DIFF
--- a/client/src/main/java/com/graphhopper/api/GraphHopperWeb.java
+++ b/client/src/main/java/com/graphhopper/api/GraphHopperWeb.java
@@ -314,6 +314,11 @@ public class GraphHopperWeb implements GraphHopperAPI {
                             ri.setExitNumber(jsonObj.getInt("exit_number"));
                         }
 
+                        if (jsonObj.has("exited")) {
+                            if (jsonObj.getBoolean("exited"))
+                                ri.setExited();
+                        }
+
                         if (jsonObj.has("turn_angle")) {
                             // TODO provide setTurnAngle setter
                             double angle = jsonObj.getDouble("turn_angle");

--- a/client/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
+++ b/client/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
@@ -103,7 +103,7 @@ public class GraphHopperWebIT {
                 RoundaboutInstruction ri = (RoundaboutInstruction) i;
                 assertEquals("turn_angle was incorrect:" + ri.getTurnAngle(), -1.5, ri.getTurnAngle(), 0.1);
                 // This route contains only one roundabout and no (via) point in a roundabout
-                assertEquals("exited was incorrect:" + ri.isExited(), true);
+                assertEquals("exited was incorrect:" + ri.isExited(), ri.isExited(),true);
             }
         }
         assertTrue("no roundabout in route?", counter > 0);

--- a/client/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
+++ b/client/src/test/java/com/graphhopper/api/GraphHopperWebIT.java
@@ -102,6 +102,8 @@ public class GraphHopperWebIT {
                 counter++;
                 RoundaboutInstruction ri = (RoundaboutInstruction) i;
                 assertEquals("turn_angle was incorrect:" + ri.getTurnAngle(), -1.5, ri.getTurnAngle(), 0.1);
+                // This route contains only one roundabout and no (via) point in a roundabout
+                assertEquals("exited was incorrect:" + ri.isExited(), true);
             }
         }
         assertTrue("no roundabout in route?", counter > 0);


### PR DESCRIPTION
This PR adds parsing of the exited roundabout value to the client. 

Currently the test is failing, as the feature is not yet live in the API.